### PR TITLE
Fixing "Creating files in an EXT4 filesystem will not set EXT4_EXTENTS_FL flag" #5 

### DIFF
--- a/fuse-ext2/op_create.c
+++ b/fuse-ext2/op_create.c
@@ -127,6 +127,20 @@ int do_create (ext2_filsys e2fs, const char *path, mode_t mode, dev_t dev, const
 		inode.i_uid = ctx->uid;
 		inode.i_gid = ctx->gid;
 	}
+	if (e2fs->super->s_feature_incompat &
+	    EXT3_FEATURE_INCOMPAT_EXTENTS) {
+		int i;
+		struct ext3_extent_header *eh;
+
+		eh = (struct ext3_extent_header *) &inode.i_block[0];
+		eh->eh_depth = 0;
+		eh->eh_entries = 0;
+		eh->eh_magic = ext2fs_cpu_to_le16(EXT3_EXT_MAGIC);
+		i = (sizeof(inode.i_block) - sizeof(*eh)) /
+			sizeof(struct ext3_extent);
+		eh->eh_max = ext2fs_cpu_to_le16(i);
+		inode.i_flags |= EXT4_EXTENTS_FL;
+	}
 
 	if (S_ISCHR(mode) || S_ISBLK(mode)) {
 		if (old_valid_dev(dev))

--- a/fuse-ext2/op_read.c
+++ b/fuse-ext2/op_read.c
@@ -31,19 +31,15 @@ int op_read (const char *path, char *buf, size_t size, off_t offset, struct fuse
 	debugf("enter");
 	debugf("path = %s", path);
 
-	efile = do_open(e2fs, path, O_RDONLY);
 	rc = ext2fs_file_llseek(efile, offset, SEEK_SET, &pos);
 	if (rc) {
-		do_release(efile);
 		return -EINVAL;
 	}
 
 	rc = ext2fs_file_read(efile, buf, size, &bytes);
 	if (rc) {
-		do_release(efile);
 		return -EIO;
 	}
-	do_release(efile);
 
 	debugf("leave");
 	return bytes;

--- a/fuse-ext2/op_write.c
+++ b/fuse-ext2/op_write.c
@@ -26,26 +26,8 @@ size_t do_write (ext2_file_t efile, const char *buf, size_t size, off_t offset)
 	const char *tmp;
 	unsigned int wr;
 	unsigned long long npos;
-#if 0
-	unsigned long long fsize;
-#endif
 
 	debugf("enter");
-
-#if 0
-	rt = ext2fs_file_get_lsize(efile, &fsize);
-	if (rt != 0) {
-		debugf("ext2fs_file_get_lsize(efile, &fsize); failed");
-		return rt;
-	}
-	if (offset + size > fsize) {
-		rt = ext2fs_file_set_size2(efile, offset + size);
-		if (rt) {
-			debugf("extfs_file_set_size(efile, %lld); failed", offset + size);
-			return rt;
-		}
-	}
-#endif
 
 	rt = ext2fs_file_llseek(efile, offset, SEEK_SET, &npos);
 	if (rt) {

--- a/fuse-ext2/op_write.c
+++ b/fuse-ext2/op_write.c
@@ -26,10 +26,13 @@ size_t do_write (ext2_file_t efile, const char *buf, size_t size, off_t offset)
 	const char *tmp;
 	unsigned int wr;
 	unsigned long long npos;
+#if 0
 	unsigned long long fsize;
+#endif
 
 	debugf("enter");
 
+#if 0
 	rt = ext2fs_file_get_lsize(efile, &fsize);
 	if (rt != 0) {
 		debugf("ext2fs_file_get_lsize(efile, &fsize); failed");
@@ -42,6 +45,7 @@ size_t do_write (ext2_file_t efile, const char *buf, size_t size, off_t offset)
 			return rt;
 		}
 	}
+#endif
 
 	rt = ext2fs_file_llseek(efile, offset, SEEK_SET, &npos);
 	if (rt) {
@@ -58,12 +62,6 @@ size_t do_write (ext2_file_t efile, const char *buf, size_t size, off_t offset)
 		return rt;
 	}
 
-	rt = ext2fs_file_flush(efile);
-	if (rt) {
-		debugf("ext2_file_flush(efile); failed");
-		return rt;
-	}
-
 	debugf("leave");
 	return wr;
 }
@@ -77,9 +75,7 @@ int op_write (const char *path, const char *buf, size_t size, off_t offset, stru
 	debugf("enter");
 	debugf("path = %s", path);
 
-	efile = do_open(e2fs, path, O_WRONLY);
 	rt = do_write(efile, buf, size, offset);
-	do_release(efile);
 
 	debugf("leave");
 	return rt;


### PR DESCRIPTION
When creating a file in a EXT4 filesystem through fuse-ext4, EXT4_EXTENTS_FL won't be set, thus all the subsequent IO operations will not build an extents tree, instead blockmap is used