### PR TITLE
Support 32-bit uids and gids

### DIFF
--- a/fuse-ext2/do_fillstatbuf.c
+++ b/fuse-ext2/do_fillstatbuf.c
@@ -42,8 +42,8 @@ void do_fillstatbuf (ext2_filsys e2fs, ext2_ino_t ino, struct ext2_inode *inode,
 	st->st_ino = ino;
 	st->st_mode = inode->i_mode;
 	st->st_nlink = inode->i_links_count;
-	st->st_uid = inode->i_uid;	/* add in uid_high */
-	st->st_gid = inode->i_gid;	/* add in gid_high */
+	st->st_uid = ext2_read_uid(inode);
+	st->st_gid = ext2_read_gid(inode);
 	if (S_ISCHR(inode->i_mode) || S_ISBLK(inode->i_mode)) {
 		if (inode->i_block[0]) {
 			st->st_rdev = old_decode_dev(ext2fs_le32_to_cpu(inode->i_block[0]));

--- a/fuse-ext2/fuse-ext2.h
+++ b/fuse-ext2/fuse-ext2.h
@@ -79,6 +79,28 @@ static inline ext2_filsys current_ext2fs(void)
 	return (ext2_filsys) e2data->e2fs;
 }
 
+static inline uid_t ext2_read_uid(struct ext2_inode *inode)
+{
+	return ((uid_t)inode->osd2.linux2.l_i_uid_high << 16) | inode->i_uid;
+}
+
+static inline void ext2_write_uid(struct ext2_inode *inode, uid_t uid)
+{
+	inode->i_uid = uid & 0xffff;
+	inode->osd2.linux2.l_i_uid_high = (uid >> 16) & 0xffff;
+}
+
+static inline gid_t ext2_read_gid(struct ext2_inode *inode)
+{
+	return ((gid_t)inode->osd2.linux2.l_i_gid_high << 16) | inode->i_gid;
+}
+
+static inline void ext2_write_gid(struct ext2_inode *inode, gid_t gid)
+{
+	inode->i_gid = gid & 0xffff;
+	inode->osd2.linux2.l_i_gid_high = (gid >> 16) & 0xffff;
+}
+
 #if ENABLE_DEBUG
 
 static inline void debug_printf (const char *function, char *file, int line, const char *fmt, ...)

--- a/fuse-ext2/op_chown.c
+++ b/fuse-ext2/op_chown.c
@@ -43,10 +43,10 @@ int op_chown (const char *path, uid_t uid, gid_t gid)
 	}
 	
 	if (uid != -1) {
-		inode.i_gid = gid;
+		inode.i_uid = uid;
 	}
 	if (gid != -1) {
-		inode.i_uid = uid;
+		inode.i_gid = gid;
 	}
 
 	rt = do_writeinode(e2fs, ino, &inode);

--- a/fuse-ext2/op_chown.c
+++ b/fuse-ext2/op_chown.c
@@ -43,10 +43,10 @@ int op_chown (const char *path, uid_t uid, gid_t gid)
 	}
 	
 	if (uid != -1) {
-		inode.i_uid = uid;
+		ext2_write_uid(&inode, uid);
 	}
 	if (gid != -1) {
-		inode.i_gid = gid;
+		ext2_write_gid(&inode, gid);
 	}
 
 	rt = do_writeinode(e2fs, ino, &inode);

--- a/fuse-ext2/op_create.c
+++ b/fuse-ext2/op_create.c
@@ -124,8 +124,8 @@ int do_create (ext2_filsys e2fs, const char *path, mode_t mode, dev_t dev, const
 	inode.i_size = 0;
 	ctx = fuse_get_context();
 	if (ctx) {
-		inode.i_uid = ctx->uid;
-		inode.i_gid = ctx->gid;
+		ext2_write_uid(&inode, ctx->uid);
+		ext2_write_gid(&inode, ctx->gid);
 	}
 	if (e2fs->super->s_feature_incompat &
 	    EXT3_FEATURE_INCOMPAT_EXTENTS) {

--- a/fuse-ext2/op_mkdir.c
+++ b/fuse-ext2/op_mkdir.c
@@ -84,8 +84,8 @@ int op_mkdir (const char *path, mode_t mode)
 	inode.i_ctime = inode.i_atime = inode.i_mtime = tm;
 	ctx = fuse_get_context();
 	if (ctx) {
-		inode.i_uid = ctx->uid;
-		inode.i_gid = ctx->gid;
+		ext2_write_uid(&inode, ctx->uid);
+		ext2_write_gid(&inode, ctx->gid);
 	}
 	rc = do_writeinode(e2fs, ino, &inode);
 	if (rc) {


### PR DESCRIPTION
These patches fix a small bug in op_chown and then implement support for 32-bit uids and gids in ext2 filesystems.