### PR TITLE
Fix typo in option allow_other

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ See [Man page](http://man.cx/fuseext2(1)) for options.
 ```
 Usage:    fuse-ext2 <device|image_file> <mount_point> [-o option[,...]]
 
-Options:  ro, force, allow_others
+Options:  ro, force, allow_other
           Please see details in the manual.
 
 Example:  fuse-ext2 /dev/sda1 /mnt/sda1

--- a/fuse-ext2/fuse-ext2.c
+++ b/fuse-ext2/fuse-ext2.c
@@ -39,7 +39,7 @@ static const char *usage_msg =
 "\n"
 "Usage:    %s <device|image_file> <mount_point> [-o option[,...]]\n"
 "\n"
-"Options:  ro, force, allow_others\n"
+"Options:  ro, force, allow_other\n"
 "          Please see details in the manual.\n"
 "\n"
 "Example:  fuse-ext2 /dev/sda1 /mnt/sda1\n"

--- a/tools/macosx/Install_resources/README.rtf
+++ b/tools/macosx/Install_resources/README.rtf
@@ -66,7 +66,7 @@ Usage\
 \
 Usage:    fuse-ext2 <device|image_file> <mount_point> [-o option[,...]]\
 \
-Options:  ro, force, allow_others\
+Options:  ro, force, allow_other\
           Please see details in the manual.\
 \
 Example:  fuse-ext2 /dev/sda1 /mnt/sda1\

--- a/tools/macosx/Install_resources/Welcome.rtf
+++ b/tools/macosx/Install_resources/Welcome.rtf
@@ -66,7 +66,7 @@ Usage\
 \
 Usage:    fuse-ext2 <device|image_file> <mount_point> [-o option[,...]]\
 \
-Options:  ro, force, allow_others\
+Options:  ro, force, allow_other\
           Please see details in the manual.\
 \
 Example:  fuse-ext2 /dev/sda1 /mnt/sda1\


### PR DESCRIPTION
Still doesn't work for me on macos sierra (can't read mount point as normal user) but this fixes the usage message and some docs to contain the right option.