### PR TITLE
fuse-ext2/Makefile.am wasn't respecting the value of $(sbindir).

### DIFF
--- a/fuse-ext2/Makefile.am
+++ b/fuse-ext2/Makefile.am
@@ -159,6 +159,6 @@ install-data-hook:
 	cd "$(DESTDIR)/$(moddir)" && rm -f $(mod_LTLIBRARIES)
 
 install-exec-local:
-	$(INSTALL) -d "$(DESTDIR)/sbin"
-	$(LN_S) -f "$(bindir)/fuse-ext2" "$(DESTDIR)/sbin/mount.fuse-ext2"
+	$(INSTALL) -d "$(DESTDIR)/$(sbindir)"
+	$(LN_S) -f "$(bindir)/fuse-ext2" "$(DESTDIR)/$(sbindir)/mount.fuse-ext2"
 endif


### PR DESCRIPTION
This could cause errors during installation as it was trying to link
fuse-ext2 to $(DESTDIR)/sbin/mount.fuse-ext2 where "sbin" may not have
been created.