### PR TITLE
Automount GPT Linux partitions

### DIFF
--- a/tools/macosx/fuse-ext2.fs/Contents/Info.plist.in
+++ b/tools/macosx/fuse-ext2.fs/Contents/Info.plist.in
@@ -148,6 +148,22 @@
 			<key>FSProbeOrder</key>
 			<integer>4900</integer>
 		</dict>
+		<key>GPT_Linux_filesystem</key>
+		<dict>
+			<key>FSMediaProperties</key>
+			<dict>
+				<key>Content Hint</key>
+				<string>0FC63DAF-8483-4772-8E79-3D69D8477DE4</string>
+				<key>Leaf</key>
+				<true/>
+			</dict>
+			<key>FSProbeArguments</key>
+			<string>-p</string>
+			<key>FSProbeExecutable</key>
+			<string>../../fuse-ext2.util</string>
+			<key>FSProbeOrder</key>
+			<integer>3500</integer>
+		</dict>
 	</dict>
 	<key>FSPersonalities</key>
 	<dict>


### PR DESCRIPTION
ext4 partitions on GPT formatted disks are not automounted. I discovered this was the case since the script was never invoked when a GPT linux disk was attached.