### PR TITLE
ENODATA is not defined on FreeBSD

### DIFF
--- a/fuse-ext2/fuse-ext2.h
+++ b/fuse-ext2/fuse-ext2.h
@@ -34,6 +34,10 @@
 #include <fuse.h>
 #include <ext2fs/ext2fs.h>
 
+#ifndef ENODATA
+#define ENODATA ENOMSG
+#endif
+
 #if !defined(FUSE_VERSION) || (FUSE_VERSION < 26)
 #error "***********************************************************"
 #error "*                                                         *"


### PR DESCRIPTION
ENODATA is not defined on FreeBSD. Define to the value of ENOMSG.