### PR TITLE
add build artifacts from running `./autogen.sh` in project root to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,21 @@ fs.ext2
 
 # IDE: PhpStorm
 .idea
+
+# Ignore build artifacts when running `autogen.sh`
+Makefile.in
+aclocal.m4
+ar-lib
+autom4te.cache/
+compile
+config.guess
+config.h.in
+config.sub
+configure
+depcomp
+fuse-ext2/Makefine.in
+install-sh
+ltmain.sh
+missing
+tools/Makefile.in
+tools/macosx/Makefile.in


### PR DESCRIPTION
I've been spending my afternoon messing around with this project, ie. the git repo so I can backup some files from my mbp to an external disk that was formatted with an ext4 filesystem a while back.

And messing around with the project I noticed when running `autogen.sh` from the project root, the shell script generates quite a few artifacts when the run completes.

This commit adds those artifacts to the `.gitignore` file which can be useful for people who are experimenting with the project for making future changes, ie. PR's to the project.