### PR TITLE
Fix compile error in MacOS 10.6 and upper (Tested in MacOS 10.14.2 with xCode 10.1)

### DIFF
--- a/tools/macosx/prefpane/English.lproj/fuse_ext2Pref.xib
+++ b/tools/macosx/prefpane/English.lproj/fuse_ext2Pref.xib
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <archive type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="7.03">
 	<data>
-		<int key="IBDocument.SystemTarget">1050</int>
+		<int key="IBDocument.SystemTarget">1060</int>
 		<string key="IBDocument.SystemVersion">9L30</string>
 		<string key="IBDocument.InterfaceBuilderVersion">677</string>
 		<string key="IBDocument.AppKitVersion">949.54</string>

--- a/tools/macosx/prefpane/fuse-ext2.xcodeproj/project.pbxproj
+++ b/tools/macosx/prefpane/fuse-ext2.xcodeproj/project.pbxproj
@@ -252,6 +252,7 @@
 				INSTALL_PATH = "$(HOME)/Library/PreferencePanes";
 				PRODUCT_NAME = "fuse-ext2";
 				SDKROOT = macosx;
+				VALID_ARCHS = x86_64;
 				WRAPPER_EXTENSION = prefPane;
 				ZERO_LINK = YES;
 			};
@@ -270,6 +271,7 @@
 				INSTALL_PATH = "$(HOME)/Library/PreferencePanes";
 				PRODUCT_NAME = "fuse-ext2";
 				SDKROOT = macosx;
+				VALID_ARCHS = x86_64;
 				WRAPPER_EXTENSION = prefPane;
 			};
 			name = Release;


### PR DESCRIPTION
#### Fix such compile error on MacOS 10.14.2:
1. error: The i386 architecture is deprecated. You should update your ARCHS build setting to remove the i386 architecture. (in target 'fuse-ext2')
2. ./fuse-ext2/tools/macosx/prefpane/English.lproj/fuse_ext2Pref.xib:global:** error: Compiling for earlier than macOS 10.6 is no longer supported.