### PR TITLE
removing duplicate include of sysmacros.h

### DIFF
--- a/fuse-ext2/fuse-ext2.h
+++ b/fuse-ext2/fuse-ext2.h
@@ -35,7 +35,6 @@
 #endif
 
 #include <fuse.h>
-#include <sys/sysmacros.h>
 #include <ext2fs/ext2fs.h>
 
 #if !defined(FUSE_VERSION) || (FUSE_VERSION < 26)


### PR DESCRIPTION
It is handled two lines above with `ifdef MAJOR_IN_SYSMACROS` condition.