### PR TITLE
Fix struct fuse_operations compatibility with libfuse version >= 3.0.

### DIFF
--- a/fuse-ext2/fuse-ext2.c
+++ b/fuse-ext2/fuse-ext2.c
@@ -314,7 +314,9 @@ static const struct fuse_operations ext2fs_ops = {
 	.lock           = NULL,
 	.utimens        = op_utimens,
 	.bmap           = NULL,
+#if ( (FUSE_VERSION) == 29 )
 	.flag_utime_omit_ok = 1,
+#endif
 };
 
 int main (int argc, char *argv[])


### PR DESCRIPTION
In commit d7c145c0, the structure `struct fuse_operations ext2fs_ops`
has bit-field member `flag_utime_omit_ok` initialized. This field has
been removed since `libfuse` version 3.0 (see libfuse/libfuse@4496de19).
As a result, compiling `fuse-ext2` with the newer `libfuse` fails.

This patch fixes this problem by selectively initialize the
`flag_utime_omit_ok` field with an `#if` guard.