### PR TITLE
Mention forbidden name `install.sh` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Building **from source** depends on the following:
 * e2fsprogs
 * xcode-select
 
-Copy and paste this into a file such as `/tmp/ext4/script.sh`.  Remember to `chmod +x script.sh`.  Run it 
+Copy and paste this into a file such as `/tmp/ext4/script.sh`, but do *not* name the file `install.sh`. Remember to `chmod +x script.sh`. Run it 
 from that directory - `./script.sh`
 
 ```shell


### PR DESCRIPTION
I tried naming the install script `install.sh` and was surprised by:

```
configure: creating ./config.status
config.status: creating fuse-ext2.pc
config.status: error: cannot find input file: `Makefile.in'
make: *** No targets specified and no makefile found.  Stop.
make: *** No rule to make target `install'.  Stop.
```

Thanks to #62 I was able to figure out why the installation failed and renamed the install script.

This pull request adds a mention to `README.md` that the file shouldn't be named `install.sh`.