### PR TITLE
Update to new syntax for installing using brew cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Look for **`homebrew/cask`** in the output.
 To install **Fuse for macOS** using brew:
 
 ```bash
-brew cask install osxfuse
+brew install --cask osxfuse
 ```
 
 ## Building


### PR DESCRIPTION
This PR updates the readme with the new syntax for installing osxfuse with Homebew

https://formulae.brew.sh/cask/osxfuse