### PR TITLE
readme: Add fuse-devel dependency for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ $ sudo make install
 
 ### Fedora 
 ```bash 
-$ sudo dnf install @development-tools m4 autoconf automake libtool e2fsprogs libcom_err-devel fuse-libs e2fsprogs-devel
+$ sudo dnf install @development-tools m4 autoconf automake libtool e2fsprogs libcom_err-devel fuse-libs e2fsprogs-devel fuse-devel
 # build part 
 $ ./autogen.sh
 $ ./configure


### PR DESCRIPTION
In order to compile `fuse-ext2` on Fedora (tested with Fedora 31 and
33), the `fuse-devel` package is also needed, otherwise `./configure`
complains that libfuse cannot be found.

Update the README file by adding the `fuse-devel` package to the list
of packages to be installed.

Signed-off-by: Daniele Alessandrelli <daniele.alessandrelli@gmail.com>