### PR TITLE
Propagate `fuse_main`'s return value

### DIFF
--- a/fuse-ext2/fuse-ext2.c
+++ b/fuse-ext2/fuse-ext2.c
@@ -377,7 +377,7 @@ int main (int argc, char *argv[])
 		debugf_main("mounting read-only");
 	}
 
-	fuse_main(fargs.argc, fargs.argv, &ext2fs_ops, &opts);
+	err = fuse_main(fargs.argc, fargs.argv, &ext2fs_ops, &opts);
 
 err_out:
 	fuse_opt_free_args(&fargs);


### PR DESCRIPTION
`fuse_main` is specified to return non-zero if mounting fails; propagate this value to allow scripts using `fuse_ext2` to detect failure using the exit code.

---
Without this, the SerenityOS build scripts can't fall back to `genext2fs` properly if the macFUSE kext is not loaded:
https://github.com/SerenityOS/serenity/blob/8cb38da92f3ec88a8817597adf79ca82690fea40/Meta/build-image-qemu.sh#L141-L145

```console
$ fuse-ext2 _disk_image mnt -o rw+,allow_other,uid=501,gid=20
mount_macfuse: the file system is not available (1)
$ echo $?
0
```